### PR TITLE
style: Tailwind + dark baseline

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "react": "^19.1.1",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,3 +1,4 @@
+/** @type {import('postcss-load-config').Config} */
 export default {
   plugins: {
     tailwindcss: {},

--- a/src/index.css
+++ b/src/index.css
@@ -6,10 +6,19 @@
   :root {
     color-scheme: light;
   }
+
   .dark {
     color-scheme: dark;
   }
+
+  html,
+  body,
+  #root {
+    @apply h-full;
+  }
+
   body {
-    @apply bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-50;
+    @apply bg-zinc-50 text-zinc-900 dark:bg-zinc-900 dark:text-zinc-50;
   }
 }
+

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,7 +3,7 @@ export default {
   darkMode: 'class',
   content: [
     './index.html',
-    './src/**/*.{js,ts,jsx,tsx}',
+    './src/**/*.{ts,tsx}',
   ],
   theme: {
     extend: {},


### PR DESCRIPTION
## Summary
- integrate Tailwind CSS with a dark zinc baseline and full-height layout
- add typecheck script and configure PostCSS for Tailwind with autoprefixer

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bafed9300483248ef3b8919b667b1a