### PR TITLE
feat(ui): add minimal ui stubs

### DIFF
--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,5 +1,5 @@
 import type { HTMLAttributes } from 'react'
-import { cn } from '@/lib/utils'
+import { cn } from '@/lib'
 
 export function Badge({ className, ...props }: HTMLAttributes<HTMLSpanElement>) {
   return (

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,13 +1,36 @@
 import type { ButtonHTMLAttributes } from 'react'
-import { cn } from '@/lib/utils'
+import { cn } from '@/lib'
 
-export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement>
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'default' | 'secondary' | 'outline'
+  size?: 'default' | 'sm' | 'icon'
+}
 
-export function Button({ className, ...props }: ButtonProps) {
+const variantStyles: Record<NonNullable<ButtonProps['variant']>, string> = {
+  default: 'bg-blue-600 text-white hover:bg-blue-700',
+  secondary: 'bg-gray-600 text-white hover:bg-gray-700',
+  outline:
+    'border border-gray-300 bg-transparent hover:bg-gray-100 dark:border-gray-700 dark:hover:bg-gray-800',
+}
+
+const sizeStyles: Record<NonNullable<ButtonProps['size']>, string> = {
+  default: 'h-10 px-4 py-2',
+  sm: 'h-9 px-3',
+  icon: 'h-10 w-10',
+}
+
+export function Button({
+  className,
+  variant = 'default',
+  size = 'default',
+  ...props
+}: ButtonProps) {
   return (
     <button
       className={cn(
-        'px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50',
+        'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none disabled:opacity-50 disabled:pointer-events-none',
+        variantStyles[variant],
+        sizeStyles[size],
         className,
       )}
       {...props}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,5 +1,5 @@
 import type { HTMLAttributes } from 'react'
-import { cn } from '@/lib/utils'
+import { cn } from '@/lib'
 
 export function Card({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
   return (
@@ -8,4 +8,18 @@ export function Card({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
       {...props}
     />
   )
+}
+
+export function CardHeader({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={cn('flex flex-col space-y-1.5 p-4', className)} {...props} />
+  )
+}
+
+export function CardTitle({ className, ...props }: HTMLAttributes<HTMLHeadingElement>) {
+  return <h3 className={cn('text-lg font-semibold leading-none', className)} {...props} />
+}
+
+export function CardContent({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('p-4 pt-0', className)} {...props} />
 }

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,11 +1,47 @@
-import type { SelectHTMLAttributes } from 'react'
-import { cn } from '@/lib/utils'
+import type {
+  HTMLAttributes,
+  OptionHTMLAttributes,
+  SelectHTMLAttributes,
+} from 'react'
+import { cn } from '@/lib'
 
-export function Select({ className, ...props }: SelectHTMLAttributes<HTMLSelectElement>) {
+export interface SelectProps
+  extends Omit<SelectHTMLAttributes<HTMLSelectElement>, 'onChange'> {
+  value?: string
+  onValueChange?: (value: string) => void
+}
+
+export function Select({
+  value,
+  onValueChange,
+  className,
+  children,
+  ...props
+}: SelectProps) {
   return (
     <select
+      value={value}
+      onChange={(e) => onValueChange?.(e.target.value)}
       className={cn('border rounded px-3 py-2 bg-white dark:bg-gray-800', className)}
       {...props}
-    />
+    >
+      {children}
+    </select>
   )
+}
+
+export function SelectTrigger({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('w-full', className)} {...props} />
+}
+
+export function SelectValue({ className, ...props }: HTMLAttributes<HTMLSpanElement>) {
+  return <span className={className} {...props} />
+}
+
+export function SelectContent({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={className} {...props} />
+}
+
+export function SelectItem({ className, ...props }: OptionHTMLAttributes<HTMLOptionElement>) {
+  return <option className={cn(className)} {...props} />
 }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: Array<string | undefined | null | false>) {
+  return classes.filter(Boolean).join(' ')
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,3 +1,0 @@
-export function cn(...classes: Array<string | undefined | false | null>) {
-  return classes.filter(Boolean).join(' ')
-}


### PR DESCRIPTION
## Summary
- implement Tailwind-based Button with variant and size props
- add Card, CardHeader, CardTitle, CardContent, and Badge components
- create lightweight Select wrapper and cn helper

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bafee28d808324ad5db0404f5a1569