### PR TITLE
feat(data): types + missions + CSM enemy registry

### DIFF
--- a/src/data/enemy/csm.ts
+++ b/src/data/enemy/csm.ts
@@ -1,0 +1,61 @@
+import type { EnemyDetachment, EnemyUnitRef } from '../types'
+import { EnemyTag, StratPhase, TurnWindow } from '../types'
+
+export const ENEMY_CORE_CSM: EnemyUnitRef[] = [
+  {
+    name: 'Abaddon the Despoiler',
+    threat: 'Durable melee character with reroll aura.',
+    tags: [EnemyTag.Durable, EnemyTag.Melee],
+  },
+  {
+    name: 'Obliterators',
+    threat: 'High damage ranged attacks, teleport.',
+    tags: [EnemyTag.Shooting],
+  },
+  {
+    name: 'Chaos Spawn',
+    threat: 'Fast objective grabbers.',
+    tags: [EnemyTag.Fast],
+  },
+]
+
+export const ENEMY_DETS_CSM: EnemyDetachment[] = [
+  {
+    name: 'Slaves to Darkness',
+    adds: [
+      {
+        name: 'Chosen',
+        threat: 'Elite infantry with strong melee.',
+        tags: [EnemyTag.Melee],
+      },
+    ],
+    defaultTraits: [
+      {
+        name: 'Dark Pact',
+        phase: StratPhase.Any,
+        window: TurnWindow.Any,
+        tip: 'Enhance attacks at the risk of mortal wounds.',
+        tags: [EnemyTag.Melee],
+      },
+    ],
+  },
+  {
+    name: 'Iron Warriors',
+    adds: [
+      {
+        name: 'Havocs',
+        threat: 'Heavy weapon squad excels at killing vehicles.',
+        tags: [EnemyTag.Shooting],
+      },
+    ],
+    defaultTraits: [
+      {
+        name: 'Bitter Enmity',
+        phase: StratPhase.Shooting,
+        window: TurnWindow.Opponent,
+        tip: 'Punish attacking their fortifications.',
+        tags: [EnemyTag.Shooting],
+      },
+    ],
+  },
+]

--- a/src/data/enemy/index.ts
+++ b/src/data/enemy/index.ts
@@ -1,0 +1,17 @@
+import type { EnemyDetachment, EnemyUnitRef } from '../types'
+import { EnemyFaction } from '../types'
+import { ENEMY_CORE_CSM, ENEMY_DETS_CSM } from './csm'
+
+export const ENEMY_CORE: Record<EnemyFaction, EnemyUnitRef[]> = {
+  [EnemyFaction.CSM]: ENEMY_CORE_CSM,
+  [EnemyFaction.SM]: [],
+  [EnemyFaction.NECRONS]: [],
+  [EnemyFaction.TYRANIDS]: [],
+}
+
+export const ENEMY_DETS: Record<EnemyFaction, EnemyDetachment[]> = {
+  [EnemyFaction.CSM]: ENEMY_DETS_CSM,
+  [EnemyFaction.SM]: [],
+  [EnemyFaction.NECRONS]: [],
+  [EnemyFaction.TYRANIDS]: [],
+}

--- a/src/data/missions.ts
+++ b/src/data/missions.ts
@@ -1,0 +1,56 @@
+import type { Deployment, MissionRule, Primary } from './types'
+import { MissionTag } from './types'
+
+export const MISSION_RULES: MissionRule[] = [
+  {
+    name: 'Delayed Reserves',
+    tip: 'Reserves cannot arrive until the third round.',
+    tags: [MissionTag.Tricksy],
+  },
+  {
+    name: 'Hidden Supplies',
+    tip: 'One objective marker is hidden until round 2.',
+    tags: [MissionTag.Action],
+  },
+  {
+    name: 'Swift Sweep',
+    tip: 'Advance before scoring primary in round 1.',
+    tags: [MissionTag.Mobility],
+  },
+]
+
+export const PRIMARY_MISSIONS: Primary[] = [
+  {
+    name: 'Take and Hold',
+    tip: 'Score for controlling objectives at end of turn.',
+    tags: [MissionTag.Hold],
+  },
+  {
+    name: 'Seek and Destroy',
+    tip: 'Score for destroying enemy units each battle round.',
+    tags: [MissionTag.Kill],
+  },
+  {
+    name: 'Data Intercept',
+    tip: 'Perform action on objectives to score progressively.',
+    tags: [MissionTag.Action],
+  },
+]
+
+export const DEPLOYMENTS: Deployment[] = [
+  {
+    name: 'Dawn of War',
+    tip: '12\" no-man\u2019s land across the center.',
+    tags: [MissionTag.Mobility],
+  },
+  {
+    name: 'Search and Destroy',
+    tip: 'Diagonal deployment with 9\" gap.',
+    tags: [MissionTag.Hold],
+  },
+  {
+    name: 'Hammer and Anvil',
+    tip: 'Long table edges with deep zones.',
+    tags: [MissionTag.Kill],
+  },
+]

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -1,0 +1,79 @@
+export const MissionTag = {
+  Hold: 'hold',
+  Kill: 'kill',
+  Action: 'action',
+  Mobility: 'mobility',
+  Tricksy: 'tricksy',
+} as const
+export type MissionTag = (typeof MissionTag)[keyof typeof MissionTag]
+
+export const EnemyTag = {
+  Durable: 'durable',
+  Melee: 'melee',
+  Shooting: 'shooting',
+  Fast: 'fast',
+  Psyker: 'psyker',
+} as const
+export type EnemyTag = (typeof EnemyTag)[keyof typeof EnemyTag]
+
+export const StratPhase = {
+  Movement: 'movement',
+  Shooting: 'shooting',
+  Charge: 'charge',
+  Fight: 'fight',
+  Any: 'any',
+} as const
+export type StratPhase = (typeof StratPhase)[keyof typeof StratPhase]
+
+export const TurnWindow = {
+  Yours: 'yours',
+  Opponent: 'opponent',
+  Any: 'any',
+} as const
+export type TurnWindow = (typeof TurnWindow)[keyof typeof TurnWindow]
+
+export interface MissionRule {
+  name: string
+  tip: string
+  tags: MissionTag[]
+}
+
+export interface Primary {
+  name: string
+  tip: string
+  tags: MissionTag[]
+}
+
+export interface Deployment {
+  name: string
+  tip: string
+  tags: MissionTag[]
+}
+
+export const EnemyFaction = {
+  CSM: 'CSM',
+  SM: 'SM',
+  NECRONS: 'NECRONS',
+  TYRANIDS: 'TYRANIDS',
+} as const
+export type EnemyFaction = (typeof EnemyFaction)[keyof typeof EnemyFaction]
+
+export interface EnemyUnitRef {
+  name: string
+  threat: string
+  tags: EnemyTag[]
+}
+
+export interface Stratagem {
+  name: string
+  phase: StratPhase
+  window: TurnWindow
+  tip: string
+  tags: EnemyTag[]
+}
+
+export interface EnemyDetachment {
+  name: string
+  adds: EnemyUnitRef[]
+  defaultTraits: Stratagem[]
+}


### PR DESCRIPTION
## Summary
- add shared data types for missions, enemies, and stratagem windows
- seed Pariah Nexus mission rules, primary missions, and deployments
- register Chaos Space Marine core threats and detachment traits

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bafeefed5483248a097393ef326e5e