### PR TITLE
feat(pregame): mission wizard

### DIFF
--- a/src/data/missions.ts
+++ b/src/data/missions.ts
@@ -40,12 +40,12 @@ export const PRIMARY_MISSIONS: Primary[] = [
 export const DEPLOYMENTS: Deployment[] = [
   {
     name: 'Dawn of War',
-    tip: '12\" no-man\u2019s land across the center.',
+    tip: '12" no-man\u2019s land across the center.',
     tags: [MissionTag.Mobility],
   },
   {
     name: 'Search and Destroy',
-    tip: 'Diagonal deployment with 9\" gap.',
+    tip: 'Diagonal deployment with 9" gap.',
     tags: [MissionTag.Hold],
   },
   {

--- a/src/pregame/MissionWizard.tsx
+++ b/src/pregame/MissionWizard.tsx
@@ -1,0 +1,92 @@
+import { useState } from 'react'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Select, SelectItem } from '@/components/ui/select'
+import { Badge } from '@/components/ui/badge'
+import { MISSION_RULES, PRIMARY_MISSIONS, DEPLOYMENTS } from '@/data/missions'
+import type { MissionTag, MissionRule, Primary, Deployment } from '@/data/types'
+
+interface MissionWizardProps {
+  onNext: (tags: MissionTag[]) => void
+}
+
+export function MissionWizard({ onNext }: MissionWizardProps) {
+  const [rule, setRule] = useState<MissionRule | undefined>()
+  const [primary, setPrimary] = useState<Primary | undefined>()
+  const [deployment, setDeployment] = useState<Deployment | undefined>()
+
+  const draw = <T,>(items: T[], setter: (value: T) => void) => {
+    const item = items[Math.floor(Math.random() * items.length)]
+    setter(item)
+  }
+
+  const handleNext = () => {
+    const tags: MissionTag[] = [
+      ...(rule?.tags ?? []),
+      ...(primary?.tags ?? []),
+      ...(deployment?.tags ?? []),
+    ]
+    onNext(tags)
+  }
+
+  const renderSection = <T extends { name: string; tip: string; tags: MissionTag[] }>(
+    label: string,
+    items: T[],
+    value: T | undefined,
+    onChange: (item: T | undefined) => void,
+    onDraw: () => void,
+  ) => (
+    <div className="space-y-2">
+      <div className="flex gap-2">
+        <Select
+          value={value?.name ?? ''}
+          onValueChange={(name) =>
+            onChange(items.find((i) => i.name === name))
+          }
+          className="flex-1"
+        >
+          <option value="">Select {label}</option>
+          {items.map((i) => (
+            <SelectItem key={i.name} value={i.name}>
+              {i.name}
+            </SelectItem>
+          ))}
+        </Select>
+        <Button onClick={onDraw} variant="secondary">
+          Draw
+        </Button>
+      </div>
+      {value && (
+        <div className="text-sm">
+          <p className="text-gray-600 dark:text-gray-300">{value.tip}</p>
+          <div className="mt-1 flex flex-wrap gap-1">
+            {value.tags.map((tag) => (
+              <Badge key={tag}>{tag}</Badge>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+
+  return (
+    <Card className="max-w-md mx-auto">
+      <CardHeader>
+        <CardTitle>Mission Setup</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {renderSection('Mission Rule', MISSION_RULES, rule, setRule, () => draw(MISSION_RULES, setRule))}
+        {renderSection('Primary Mission', PRIMARY_MISSIONS, primary, setPrimary, () => draw(PRIMARY_MISSIONS, setPrimary))}
+        {renderSection('Deployment', DEPLOYMENTS, deployment, setDeployment, () => draw(DEPLOYMENTS, setDeployment))}
+        <div className="pt-2">
+          <Button onClick={handleNext} disabled={!rule || !primary || !deployment} className="w-full">
+            Next
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+export default MissionWizard
+


### PR DESCRIPTION
## Summary
- add MissionWizard for selecting and drawing mission rules, primaries, and deployments
- clean up deployment tip strings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bb04cc71048324a5155532f0593a67