### PR TITLE
feat(app): wire pregame flow (wizard → enemy)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,26 +1,85 @@
 import { useState } from 'react'
-import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
-import { Select } from '@/components/ui/select'
+import MissionWizard from '@/pregame/MissionWizard'
+import EnemySelector from '@/pregame/EnemySelector'
+import type { MissionTag, EnemyTag } from '@/data/types'
 
 function App() {
-  const [count, setCount] = useState(0)
+  const [step, setStep] = useState(0)
+  const [missionTags, setMissionTags] = useState<MissionTag[]>([])
+  const [enemyTags, setEnemyTags] = useState<EnemyTag[]>([])
+
+  const handleMissionNext = (tags: MissionTag[]) => {
+    setMissionTags(tags)
+    setStep(1)
+  }
+
+  const handleEnemyStart = (tags: EnemyTag[]) => {
+    setEnemyTags(tags)
+    setStep(2)
+  }
+
+  const Stepper = () => (
+    <div className="mb-4 flex items-center justify-center gap-4">
+      <div className="flex items-center gap-2">
+        <div
+          className={`flex h-8 w-8 items-center justify-center rounded-full border ${
+            step >= 0 ? 'border-blue-600 bg-blue-600 text-white' : 'border-gray-300 text-gray-500'
+          }`}
+        >
+          1
+        </div>
+        <span className={step >= 0 ? 'font-medium text-blue-600' : 'text-gray-500'}>
+          Mission
+        </span>
+      </div>
+      <div className={`h-px w-8 ${step > 0 ? 'bg-blue-600' : 'bg-gray-300'}`} />
+      <div className="flex items-center gap-2">
+        <div
+          className={`flex h-8 w-8 items-center justify-center rounded-full border ${
+            step >= 1 ? 'border-blue-600 bg-blue-600 text-white' : 'border-gray-300 text-gray-500'
+          }`}
+        >
+          2
+        </div>
+        <span className={step >= 1 ? 'font-medium text-blue-600' : 'text-gray-500'}>
+          Enemy
+        </span>
+      </div>
+    </div>
+  )
 
   return (
     <main className="p-8">
-      <Card className="p-6 space-y-4 max-w-md mx-auto">
-        <h1 className="text-2xl font-bold">
-          Vite + React <Badge className="ml-2">Tailwind</Badge>
-        </h1>
-        <Button onClick={() => setCount((c) => c + 1)}>Count is {count}</Button>
-        <Select defaultValue="light" className="mt-2">
-          <option value="light">Light</option>
-          <option value="dark">Dark</option>
-        </Select>
-      </Card>
+      {step < 2 ? (
+        <Card className="mx-auto max-w-xl space-y-4 p-6">
+          <Stepper />
+          {step === 0 ? (
+            <MissionWizard onNext={handleMissionNext} />
+          ) : (
+            <EnemySelector onStart={handleEnemyStart} />
+          )}
+        </Card>
+      ) : (
+        <Card className="mx-auto max-w-md space-y-4 p-6 text-center">
+          <h2 className="text-2xl font-bold">Setup Complete</h2>
+          <p className="text-gray-600 dark:text-gray-300">Gameplay shell coming soon.</p>
+          <div className="flex flex-wrap justify-center gap-1">
+            {missionTags.map((tag) => (
+              <Badge key={tag}>{tag}</Badge>
+            ))}
+            {enemyTags.map((tag) => (
+              <Badge key={tag} className="bg-gray-700 text-white">
+                {tag}
+              </Badge>
+            ))}
+          </div>
+        </Card>
+      )}
     </main>
   )
 }
 
 export default App
+


### PR DESCRIPTION
## Summary
- add 2-step pregame card with Stepper
- integrate MissionWizard and EnemySelector to capture mission & enemy tags
- show placeholder setup completion section

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bb0f1bc730832488bd53c50724e651