### PR TITLE
feat(advice): tag meta, types, rule engine, AdvicePane scaffold

### DIFF
--- a/src/data/advice/types.ts
+++ b/src/data/advice/types.ts
@@ -1,0 +1,30 @@
+export type AdvicePhase = 'any' | 'command' | 'movement' | 'shooting' | 'charge' | 'fight' | 'end'
+export type AdviceWindow = 'my' | 'opp' | 'both'
+
+export type ScopedTags = {
+  tags: string[]
+  side?: 'ours' | 'enemy' | 'any'
+}
+
+export type AdviceCondition = {
+  phase?: AdvicePhase | AdvicePhase[]
+  window?: AdviceWindow
+  requireAnyTags?: ScopedTags
+  requireAllTags?: ScopedTags
+  forbidTags?: ScopedTags
+  minCP?: number
+  maxTurn?: number
+  minTurn?: number
+}
+
+export type AdviceCard = {
+  id: string
+  title: string
+  body: string
+  phase: AdvicePhase
+  window: AdviceWindow
+  importance: 1 | 2 | 3
+  oncePerGame?: boolean
+  conditions: AdviceCondition
+  refs?: string[]
+}

--- a/src/data/tags.ts
+++ b/src/data/tags.ts
@@ -1,0 +1,53 @@
+export type TagCategory = 'mission' | 'unit' | 'board' | 'tempo' | 'risk'
+
+export type TagMeta = {
+  key: string
+  label?: string
+  category: TagCategory
+  severity?: 1 | 2 | 3
+  synonyms?: string[]
+}
+
+export const TAG_META: Record<string, TagMeta> = {
+  // --- unit capabilities / archetype ---
+  'deep-strike':       { key: 'deep-strike', category: 'unit', severity: 3, synonyms: ['reinforcements'] },
+  'indirect':          { key: 'indirect', category: 'unit', severity: 3 },
+  'long-range-at':     { key: 'long-range-at', category: 'unit', severity: 3 },
+  'fast-melee':        { key: 'fast-melee', category: 'unit', severity: 2 },
+  'melee-brick':       { key: 'melee-brick', category: 'unit', severity: 3 },
+  'transport':         { key: 'transport', category: 'unit', severity: 2 },
+  'transport-push':    { key: 'transport-push', category: 'unit', severity: 2 },
+  'gunline':           { key: 'gunline', category: 'unit', severity: 2 },
+  'vehicle-wall':      { key: 'vehicle-wall', category: 'unit', severity: 2 },
+  'stealth':           { key: 'stealth', category: 'unit', severity: 1 },
+  'fall-back-charge':  { key: 'fall-back-charge', category: 'unit', severity: 2 },
+  'post-fight-move':   { key: 'post-fight-move', category: 'unit', severity: 2 },
+  'ignores-cover':     { key: 'ignores-cover', category: 'unit', severity: 2 },
+  'mortal-wounds':     { key: 'mortal-wounds', category: 'unit', severity: 2 },
+  'high-invul':        { key: 'high-invul', category: 'unit', severity: 2 },
+  '2plus-save':        { key: '2plus-save', category: 'unit', severity: 2 },
+  'minus1-damage':     { key: 'minus1-damage', category: 'unit', severity: 2 },
+  'return-models':     { key: 'return-models', category: 'unit', severity: 2 },
+  'advance-and-charge':{ key: 'advance-and-charge', category: 'unit', severity: 2 },
+
+  // --- mission properties ---
+  'action-pressure':   { key: 'action-pressure', category: 'mission', severity: 2 },
+  'late-spike':        { key: 'late-spike', category: 'mission', severity: 2 },
+  'center':            { key: 'center', category: 'mission', severity: 1 },
+  'home-obj':          { key: 'home-obj', category: 'mission', severity: 1 },
+  'redeploy':          { key: 'redeploy', category: 'mission', severity: 1 },
+  'reserves-boost':    { key: 'reserves-boost', category: 'mission', severity: 1 },
+  'short-dist':        { key: 'short-dist', category: 'mission', severity: 1 },
+  'mid-dist':          { key: 'mid-dist', category: 'mission', severity: 1 },
+  'long-dist':         { key: 'long-dist', category: 'mission', severity: 1 },
+
+  // --- our capabilities (we’ll add toggles/inference later) ---
+  'screening':         { key: 'screening', category: 'unit', severity: 3, synonyms: ['infiltrator-bubble'] },
+  'countercharge':     { key: 'countercharge', category: 'unit', severity: 2 },
+  'anti-tank':         { key: 'anti-tank', category: 'unit', severity: 3 },
+
+  // --- tempo/board state (optional ambient tags) ---
+  'cp-low':            { key: 'cp-low', category: 'tempo', severity: 2 },
+  'behind-on-primaries': { key: 'behind-on-primaries', category: 'tempo', severity: 3 },
+}
+

--- a/src/gameplay/AdvicePane.tsx
+++ b/src/gameplay/AdvicePane.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import type { AdviceCard } from '@/data/advice/types'
+import type { AdviceContext } from '@/lib/advice'
+import { selectAdvice } from '@/lib/advice'
+
+type AdvicePaneProps = {
+  ctx: AdviceContext
+  cards?: AdviceCard[]
+  title?: string
+}
+
+export default function AdvicePane({ ctx, cards = [], title = 'Advice' }: AdvicePaneProps) {
+  const top = React.useMemo(() => selectAdvice(cards, ctx, 6), [cards, ctx])
+
+  return (
+    <Card className="bg-zinc-800 text-white rounded-xl border-zinc-700">
+      <CardHeader>
+        <CardTitle className="text-sm">{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {top.length === 0 ? (
+          <div className="text-sm text-zinc-400">No advice yet for this phase/context.</div>
+        ) : (
+          <ul className="space-y-2">
+            {top.map(a => (
+              <li key={a.id} className="rounded-lg border border-zinc-700/70 bg-zinc-900/50 p-3">
+                <div className="text-sm font-medium">{a.title}</div>
+                <div className="text-xs text-zinc-300 mt-1">{a.body}</div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/lib/advice.ts
+++ b/src/lib/advice.ts
@@ -1,0 +1,63 @@
+import { TAG_META } from '@/data/tags'
+import type { AdviceCard, AdviceCondition, AdvicePhase, AdviceWindow, ScopedTags } from '@/data/advice/types'
+
+export type AdviceContext = {
+  forces: { ours: Set<string>; enemy: Set<string> }
+  ambient: Set<string>
+  phase: AdvicePhase
+  window: AdviceWindow
+  turn: number
+  cp: number
+}
+
+export function matches(cond: AdviceCondition, ctx: AdviceContext): boolean {
+  if (cond.phase) {
+    const list = Array.isArray(cond.phase) ? cond.phase : [cond.phase]
+    if (!list.includes(ctx.phase)) return false
+  }
+  if (cond.window && cond.window !== 'both' && cond.window !== ctx.window) return false
+  if (typeof cond.minTurn === 'number' && ctx.turn < cond.minTurn) return false
+  if (typeof cond.maxTurn === 'number' && ctx.turn > cond.maxTurn) return false
+  if (typeof cond.minCP === 'number' && ctx.cp < cond.minCP) return false
+
+  if (cond.requireAllTags && !hasAll(cond.requireAllTags, ctx)) return false
+  if (cond.requireAnyTags && !hasAny(cond.requireAnyTags, ctx)) return false
+  if (cond.forbidTags && hasAny(cond.forbidTags, ctx)) return false
+
+  return true
+}
+
+export function scoreAdvice(card: AdviceCard, ctx: AdviceContext): number {
+  let score = card.importance
+  if (card.phase === ctx.phase || card.phase === 'any') score += 0.5
+  const related = [
+    ...(card.conditions.requireAllTags?.tags ?? []),
+    ...(card.conditions.requireAnyTags?.tags ?? []),
+  ]
+  for (const k of related) {
+    const sev = TAG_META[k]?.severity ?? 0
+    if (sev) score += sev * 0.25
+  }
+  return score
+}
+
+function pickSets(side: ScopedTags['side'] | undefined, ctx: AdviceContext): Set<string>[] {
+  if (side === 'ours') return [ctx.forces.ours]
+  if (side === 'enemy') return [ctx.forces.enemy]
+  return [ctx.forces.ours, ctx.forces.enemy, ctx.ambient]
+}
+
+function hasAll(scoped: ScopedTags, ctx: AdviceContext): boolean {
+  const sets = pickSets(scoped.side, ctx)
+  return scoped.tags.every(t => sets.some(s => s.has(t)))
+}
+
+function hasAny(scoped: ScopedTags, ctx: AdviceContext): boolean {
+  const sets = pickSets(scoped.side, ctx)
+  return scoped.tags.some(t => sets.some(s => s.has(t)))
+}
+
+export function selectAdvice(cards: AdviceCard[], ctx: AdviceContext, limit = 6): AdviceCard[] {
+  const eligible = cards.filter(c => matches(c.conditions, ctx))
+  return eligible.sort((a, b) => scoreAdvice(b, ctx) - scoreAdvice(a, ctx)).slice(0, limit)
+}


### PR DESCRIPTION
## Summary
- generalize unit capability tags under unified `unit` category
- allow advice conditions to specify tag side scopes
- adjust advice context and rule engine to track our and enemy tags separately

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb1dbd0ec88324a8995550d535eb5d