### PR TITLE
feat(state): persist pre-game + gameplay state and wire Reset (match-aware)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,27 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Card } from "@/components/ui/card";
 import MissionWizard from "@/pregame/MissionWizard";
 import EnemySelector from "@/pregame/EnemySelector";
 import GameplayShell from "@/gameplay/GameplayShell";
+import { getJSON, setJSON } from "@/lib/storage";
+import {
+  MISSION_RULES,
+  PRIMARY_MISSIONS,
+  DEPLOYMENTS,
+} from "@/data/missions";
+import { TAG_META } from "@/data/tags";
+
+interface CurrentMatchRecord {
+  matchKey: string;
+  mission?: {
+    ruleName: string;
+    primaryName: string;
+    deploymentName: string;
+    tags: string[];
+  };
+  units?: { tags: string[] };
+  started?: boolean;
+}
 
 import type {
   MissionRule,
@@ -14,6 +33,7 @@ import type {
 
 function App() {
   const [step, setStep] = useState(0);
+  const [matchKey, setMatchKey] = useState("");
 
   const [mission, setMission] = useState<{
     rule: MissionRule;
@@ -24,19 +44,106 @@ function App() {
 
   const [enemyTags, setEnemyTags] = useState<EnemyTag[]>([]);
 
+  useEffect(() => {
+    const record = getJSON<CurrentMatchRecord | null>(
+      "smcg.match.current",
+      null,
+    );
+
+    if (record && record.matchKey) {
+      setMatchKey(record.matchKey);
+
+      const rule = MISSION_RULES.find(
+        (r) => r.name === record.mission?.ruleName,
+      );
+      const primary = PRIMARY_MISSIONS.find(
+        (p) => p.name === record.mission?.primaryName,
+      );
+      const deployment = DEPLOYMENTS.find(
+        (d) => d.name === record.mission?.deploymentName,
+      );
+
+      if (rule && primary && deployment && record.mission) {
+        const tags = (record.mission.tags || []).filter(
+          (t): t is MissionTag => typeof t === "string",
+        );
+        setMission({ rule, primary, deployment, tags });
+        setStep(1);
+      }
+
+      if (record.units?.tags) {
+        const validTags = record.units.tags.filter(
+          (t): t is EnemyTag => typeof t === "string" && t in TAG_META,
+        );
+        setEnemyTags(validTags);
+      }
+
+      if (record.started && rule && primary && deployment) {
+        setStep(2);
+      }
+    }
+  }, []);
+
   const handleMissionNext = (missionData: {
     rule: MissionRule;
     primary: Primary;
     deployment: Deployment;
     tags: MissionTag[];
   }) => {
+    const key = matchKey || Date.now().toString();
+    setMatchKey(key);
     setMission(missionData);
+    setEnemyTags([]);
     setStep(1);
+
+    setJSON("smcg.match.current", {
+      matchKey: key,
+      mission: {
+        ruleName: missionData.rule.name,
+        primaryName: missionData.primary.name,
+        deploymentName: missionData.deployment.name,
+        tags: missionData.tags,
+      },
+      units: { tags: [] },
+      started: false,
+    });
   };
 
   const handleEnemyStart = (tags: EnemyTag[]) => {
+    const key = matchKey || Date.now().toString();
+    setMatchKey(key);
     setEnemyTags(tags);
     setStep(2);
+
+    const current =
+      getJSON<CurrentMatchRecord | null>("smcg.match.current", null) ||
+      ({ matchKey: key } as CurrentMatchRecord);
+    setJSON("smcg.match.current", {
+      ...current,
+      matchKey: key,
+      units: { tags },
+      started: true,
+    });
+  };
+
+  const handleReset = () => {
+    if (typeof localStorage !== "undefined") {
+      localStorage.removeItem("smcg.match.current");
+      if (matchKey) {
+        localStorage.removeItem(`smcg.match.${matchKey}.game`);
+        const prefix = `smcg.match.${matchKey}.advice.`;
+        const keys: string[] = [];
+        for (let i = 0; i < localStorage.length; i++) {
+          const k = localStorage.key(i);
+          if (k && k.startsWith(prefix)) keys.push(k);
+        }
+        keys.forEach((k) => localStorage.removeItem(k));
+      }
+    }
+    setMission(null);
+    setEnemyTags([]);
+    setMatchKey("");
+    setStep(0);
   };
 
   const Stepper = () => (
@@ -89,11 +196,8 @@ function App() {
           <GameplayShell
             mission={mission}
             unitTags={enemyTags}
-            onReset={() => {
-              setStep(0);
-              setMission(null);
-              setEnemyTags([]);
-            }}
+            matchKey={matchKey}
+            onReset={handleReset}
           />
         )
       )}

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -5,6 +5,11 @@ export function getJSON<T>(key: string, fallback: T): T {
     if (!raw) return fallback
     return JSON.parse(raw) as T
   } catch {
+    try {
+      localStorage.removeItem(key)
+    } catch {
+      // ignore
+    }
     return fallback
   }
 }


### PR DESCRIPTION
## Summary
- add matchKey-aware localStorage helpers to persist mission, unit tags, and gameplay state
- scope AdvicePane and gameplay controls by match and persist/restore them across refreshes
- implement match reset to clear storage and return to pre-game

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb2f5056e08324a96b18240cb9fa61